### PR TITLE
Deprecate RichListenableFuture in favor of converting ListenableFuture to a Scala Future.

### DIFF
--- a/src/main/scala/com/gilt/gfc/guava/future/GuavaFutures.scala
+++ b/src/main/scala/com/gilt/gfc/guava/future/GuavaFutures.scala
@@ -107,6 +107,7 @@ object GuavaFutures {
 
 private object RichListenableFuture extends OpenLoggable
 
+@deprecated("Convert a ListenableFuture to a Scala Future instead", "0.1.2")
 case class RichListenableFuture[T](future: ListenableFuture[T]) {
 
   import RichListenableFuture._


### PR DESCRIPTION
Under the hood RichListenableFuture relies on Guava's transform function without specifying an executor to execute the transformation. From the Guava documentation:

_Note: If the transformation is slow or heavyweight, consider supplying an executor. If you do not supply an executor, transform will use sameThreadExecutor, which carries some caveats for heavier operations. For example, the call to function.apply may run on an unpredictable or undesirable thread:_

  * _If the input Future is done at the time transform is called, transform will call function.apply inline._
  * _If the input Future is not yet done, transform will schedule function.apply to be run by the thread that completes the input Future, which may be an internal system thread such as an RPC network thread._

This is obviously not terribly safe. Using a Scala Future is a much better option so deprecating RichListenableFuture seems like a good path forward.